### PR TITLE
Make dark mode turn automatically on if user's system prefers it

### DIFF
--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20152,7 +20152,8 @@ function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
   var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
 	console.log(localStorage)
-  	if (checkPreference && !localStorage.hasOwnProperty('darkMode')) {
+	var containsDarkMode = 'darkMode' in localStorage;
+  	if (checkPreference && !containsDarkMode) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
   		localStorage.setItem('darkMode', 'true');

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20151,7 +20151,7 @@ Webflow.define('tabs', module.exports = function ($) {
 function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
   var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
-	console.log(localStorage.getItem('darkMode'))
+	console.log(localStorage)
   	if (checkPreference && localStorage.getItem('darkMode') != null) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20152,7 +20152,7 @@ function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
   var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
 
-  	if (checkPreference) {
+  	if (checkPreference && !localStorage.getItem('darkMode')) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
   		localStorage.setItem('darkMode', 'true');

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20152,7 +20152,7 @@ function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
   var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
 	console.log(localStorage)
-  	if (checkPreference && localStorage.hasOwnProperty('darkMode')) {
+  	if (checkPreference && !localStorage.hasOwnProperty('darkMode')) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
   		localStorage.setItem('darkMode', 'true');
@@ -20167,6 +20167,7 @@ function reloadTheme(checkPreference){
     localStorage.setItem('darkMode', switchToTheme);
     reloadTheme(false);
   }
+
   if(localStorage.getItem('darkMode') == "true"){
     if(!document.getElementById('darkThemeLink')){
       var file = location.pathname.split( "/" ).pop();

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20152,7 +20152,7 @@ function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
   var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
 
-  	if (checkPreference && !localStorage.getItem('darkMode')) {
+  	if (checkPreference) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
   		localStorage.setItem('darkMode', 'true');

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20154,10 +20154,8 @@ function reloadTheme(checkPreference){
 
   	if (checkPreference) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-	  console.log("userprefersdark: " + userPrefersDark)
-	  console.log(localStorage.getItem('darkMode'))
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
-  		localStorage.setItem('darkMode', 'true')
+  		localStorage.setItem('darkMode', 'true');
   	  }
 
   	 }
@@ -20167,8 +20165,6 @@ function reloadTheme(checkPreference){
   themeSwitcher.onclick = function() {
     var currentTheme = localStorage.getItem('darkMode');
     var switchToTheme = currentTheme === "true" ? "false" : "true"
-    console.log("currently on theme: " + currentTheme)
-    console.log("switching to " + switchToTheme)
     localStorage.setItem('darkMode', switchToTheme);
     reloadTheme(false);
   }

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20152,7 +20152,7 @@ function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
   var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
 
-  	if (checkPreference) {
+  	if (checkPreference && localStorage.getItem('darkMode') != null) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
   		localStorage.setItem('darkMode', 'true');

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20151,14 +20151,13 @@ Webflow.define('tabs', module.exports = function ($) {
 function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
   var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
-
+	console.log(localStorage.getItem('darkMode'))
   	if (checkPreference && localStorage.getItem('darkMode') != null) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
   		localStorage.setItem('darkMode', 'true');
   	  }
-
-  	 }
+  	}
 
 
   themeSwitcher.innerHTML = themeSwitcherTrueText + (localStorage.getItem('darkMode') == "true"? " Light Mode":" Dark Mode");

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20148,15 +20148,29 @@ Webflow.define('tabs', module.exports = function ($) {
   return api;
 });
 
-function reloadTheme(){
+function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
-  var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1); 
+  var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
+
+  	if (checkPreference) {
+  	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+	  console.log("userprefersdark: " + userPrefersDark)
+	  console.log(localStorage.getItem('darkMode'))
+  	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
+  		localStorage.setItem('darkMode', 'true')
+  	  }
+
+  	 }
+
+
   themeSwitcher.innerHTML = themeSwitcherTrueText + (localStorage.getItem('darkMode') == "true"? " Light Mode":" Dark Mode");
   themeSwitcher.onclick = function() {
     var currentTheme = localStorage.getItem('darkMode');
     var switchToTheme = currentTheme === "true" ? "false" : "true"
+    console.log("currently on theme: " + currentTheme)
+    console.log("switching to " + switchToTheme)
     localStorage.setItem('darkMode', switchToTheme);
-    reloadTheme();
+    reloadTheme(false);
   }
   if(localStorage.getItem('darkMode') == "true"){
     if(!document.getElementById('darkThemeLink')){
@@ -20175,7 +20189,7 @@ function reloadTheme(){
   }
 }
 document.addEventListener("DOMContentLoaded", function(event) {
-  reloadTheme();
+  reloadTheme(true);
 });
 
 function loadTheme(){

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -20152,7 +20152,7 @@ function reloadTheme(checkPreference){
   var themeSwitcher = document.getElementById("theme-switcher");
   var themeSwitcherTrueText = themeSwitcher.innerHTML.slice(0, themeSwitcher.innerHTML.indexOf(">") + 1);
 	console.log(localStorage)
-  	if (checkPreference && localStorage.getItem('darkMode') != null) {
+  	if (checkPreference && localStorage.hasOwnProperty('darkMode')) {
   	  const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   	  if (userPrefersDark && localStorage.getItem('darkMode') === 'false') {
   		localStorage.setItem('darkMode', 'true');


### PR DESCRIPTION
If the user's system theme is set to be dark, dark mode for the website is automatically toggled on when viewing the site. Only works on Windows and Mac OS.