### PR TITLE
Remove `.html` suffix everywhere and make 404 page work on subdirectories

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,17 +8,17 @@
   <meta content="Not Found" property="twitter:title">
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <meta content="Webflow" name="generator">
-  <link href="css/normalize.css" rel="stylesheet" type="text/css">
-  <link href="css/webflow.css" rel="stylesheet" type="text/css">
-  <link href="css/iris-2.webflow.css" rel="stylesheet" type="text/css">
+  <link href="/css/normalize.css" rel="stylesheet" type="text/css">
+  <link href="/css/webflow.css" rel="stylesheet" type="text/css">
+  <link href="/css/iris-2.webflow.css" rel="stylesheet" type="text/css">
   <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
   <script type="text/javascript">WebFont.load({  google: {    families: ["Open Sans:300,300italic,400,400italic,600,600italic,700,700italic,800,800italic","Roboto:300,regular,500"]  }});</script>
   <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
   <script type="text/javascript">!function(o,c){let n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon">
-  <link href="images/webclip.webp" rel="apple-touch-icon">
-  <script defer="" src="js/lang.js" type="text/javascript"></script>
-  <script defer="" src="js/darkmode.js" type="text/javascript"></script>
+  <link href="/images/favicon.ico" rel="shortcut icon" type="image/x-icon">
+  <link href="/images/webclip.webp" rel="apple-touch-icon">
+  <script defer="" src="/js/lang.js" type="text/javascript"></script>
+  <script defer="" src="/js/darkmode.js" type="text/javascript"></script>
 </head>
 <body>
   <div class="utility-page-wrap">
@@ -26,12 +26,12 @@
       <h2 class="heading-7">Page Not Found</h2>
       <div class="text-block-8">The page you are looking for doesn&#x27;t exist or has been moved</div>
       <div class="w-container">
-        <a href="index.html" class="w-button">Return to Iris Home</a>
+        <a href="/" class="w-button">Return to Iris Home</a>
       </div>
     </div>
   </div>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=60b6a6f4e6d29054cd497fb4" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-  <script src="js/webflow.min.js" type="text/javascript"></script>
+  <script src="/js/webflow.min.js" type="text/javascript"></script>
   <!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -51,7 +51,7 @@
         localStorage.setItem("darkMode", userPrefersDark ? "true" : "false");
       }
       document.addEventListener("DOMContentLoaded", function (event) {
-        reloadTheme("about.html");
+        reloadTheme("about");
         initLang(1);
       });
     </script>
@@ -78,32 +78,32 @@
           alt=""
           class="image"
         />
-        <a href="index.html" class="brand-link w-nav-brand">
+        <a href="/" class="brand-link w-nav-brand">
           <h1 class="brand-text">Iris Shaders</h1>
         </a>
         <nav role="navigation" class="navigation-menu w-nav-menu">
           <a
-            href="index.html"
+            href="/"
             langfield="home"
             class="navigation-link w-nav-link"
             >Home</a
           >
           <link rel="prefetch" href="/" />
           <a
-            href="about.html"
+            href="/"
             langfield="about"
             aria-current="page"
             class="navigation-link w-nav-link w--current"
             >Learn More</a
           >
-          <link rel="prefetch" href="/about.html" />
+          <link rel="prefetch" href="/about" />
           <a
-            href="download.html"
+            href="download"
             langfield="download"
             class="navigation-link-button w-nav-link"
             >Download Now</a
           >
-          <link rel="prerender" href="/download.html" />
+          <link rel="prerender" href="/download" />
           <img
             src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg"
             loading="lazy"
@@ -136,7 +136,7 @@
           "
         >
           <a
-            href="index.html"
+            href="/"
             langfield="home"
             aria-current="page"
             class="navigation-link w-nav-link w--nav-link-open"
@@ -144,19 +144,19 @@
           >
           <link rel="prefetch" href="/" />
           <a
-            href="about.html"
+            href="about"
             langfield="about"
             class="navigation-link w-nav-link w--current w--nav-link-open"
             >Learn More</a
           >
-          <link rel="prefetch" href="/about.html" />
+          <link rel="prefetch" href="/about" />
           <a
-            href="download.html"
+            href="download"
             langfield="download"
             class="navigation-link-button w-nav-link w--nav-link-open"
             >Download Now</a
           >
-          <link rel="prerender" href="/download.html" /><img
+          <link rel="prerender" href="/download" /><img
             src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg"
             loading="lazy"
             width="15"
@@ -670,13 +670,13 @@
           <div class="spc w-col w-col-4">
             <h5 langfield="footer2" class="heading-9">useful links</h5>
             <a
-              href="about.html"
+              href="about"
               langfield="about"
               aria-current="page"
               class="footer-link w--current"
               >Learn More</a
             >
-            <a href="download.html" langfield="download" class="footer-link"
+            <a href="download" langfield="download" class="footer-link"
               >Download Now</a
             >
             <a

--- a/download.html
+++ b/download.html
@@ -51,7 +51,7 @@
         localStorage.setItem("darkMode", userPrefersDark ? "true" : "false");
       }
       document.addEventListener("DOMContentLoaded", function (event) {
-        reloadTheme("download.html");
+        reloadTheme("download");
         initLang(2);
       });
     </script>
@@ -78,32 +78,32 @@
           alt=""
           class="image"
         />
-        <a href="index.html" class="brand-link w-nav-brand">
+        <a href="/" class="brand-link w-nav-brand">
           <h1 class="brand-text">Iris Shaders</h1>
         </a>
         <nav role="navigation" class="navigation-menu w-nav-menu">
           <a
-            href="index.html"
+            href="/"
             langfield="home"
             class="navigation-link w-nav-link"
             >Home</a
           >
           <link rel="prefetch" href="/" />
           <a
-            href="about.html"
+            href="about"
             langfield="about"
             class="navigation-link w-nav-link"
             >Learn More</a
           >
-          <link rel="prefetch" href="/about.html" />
+          <link rel="prefetch" href="/about" />
           <a
-            href="download.html"
+            href="download"
             langfield="download"
             aria-current="page"
             class="navigation-link-button w-nav-link w--current"
             >Download Now</a
           >
-          <link rel="prerender" href="/download.html" /><img
+          <link rel="prerender" href="/download" /><img
             src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg"
             loading="lazy"
             width="15"
@@ -135,7 +135,7 @@
           "
         >
           <a
-            href="index.html"
+            href="/"
             langfield="home"
             aria-current="page"
             class="navigation-link w-nav-link w--nav-link-open"
@@ -143,14 +143,14 @@
           >
           <link rel="prefetch" href="/" />
           <a
-            href="about.html"
+            href="about"
             langfield="about"
             class="navigation-link w-nav-link w--nav-link-open"
             >Learn More</a
           >
-          <link rel="prefetch" href="/about.html" />
+          <link rel="prefetch" href="/about" />
           <a
-            href="download.html"
+            href="download"
             langfield="download"
             class="
               navigation-link-button
@@ -158,7 +158,7 @@
             "
             >Download Now</a
           >
-          <link rel="prerender" href="/download.html" /><img
+          <link rel="prerender" href="/download" /><img
             src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg"
             loading="lazy"
             width="15"
@@ -294,11 +294,11 @@
           </div>
           <div class="spc w-col w-col-4">
             <h5 langfield="footer2" class="heading-9">useful links</h5>
-            <a href="about.html" langfield="about" class="footer-link"
+            <a href="about" langfield="about" class="footer-link"
               >Learn More</a
             >
             <a
-              href="download.html"
+              href="download"
               langfield="download"
               aria-current="page"
               class="footer-link w--current"

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
           class="image"
         />
         <a
-          href="index.html"
+          href="/"
           aria-current="page"
           class="brand-link w-nav-brand w--current"
         >
@@ -87,7 +87,7 @@
         </a>
         <nav role="navigation" class="navigation-menu w-nav-menu" id="bigNav">
           <a
-            href="index.html"
+            href="/"
             langfield="home"
             aria-current="page"
             class="navigation-link w-nav-link w--current"
@@ -95,19 +95,19 @@
           >
           <link rel="prefetch" href="/" />
           <a
-            href="about.html"
+            href="about"
             langfield="about"
             class="navigation-link w-nav-link"
             >Learn More</a
           >
-          <link rel="prefetch" href="/about.html" />
+          <link rel="prefetch" href="/about" />
           <a
-            href="download.html"
+            href="download"
             langfield="download"
             class="navigation-link-button w-nav-link"
             >Download Now</a
           >
-          <link rel="prerender" href="/download.html" />
+          <link rel="prerender" href="/download" />
           <img
             src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg"
             loading="lazy"
@@ -140,7 +140,7 @@
           "
         >
           <a
-            href="index.html"
+            href="/"
             langfield="home"
             aria-current="page"
             class="navigation-link w-nav-link w--current w--nav-link-open"
@@ -148,19 +148,19 @@
           >
           <link rel="prefetch" href="/" />
           <a
-            href="about.html"
+            href="/"
             langfield="about"
             class="navigation-link w-nav-link w--nav-link-open"
             >Learn More</a
           >
-          <link rel="prefetch" href="/about.html" />
+          <link rel="prefetch" href="/about" />
           <a
-            href="download.html"
+            href="download"
             langfield="download"
             class="navigation-link-button w-nav-link w--nav-link-open"
             >Download Now</a
           >
-          <link rel="prerender" href="/download.html" /><img
+          <link rel="prerender" href="/download" /><img
             src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg"
             loading="lazy"
             width="15"
@@ -202,13 +202,13 @@
         </div>
         <div data-ix="fade-in-bottom-page-loads" class="div-block">
           <a
-            href="download.html"
+            href="download"
             langfield="download"
             data-w-id="6c5fe302-eed3-af1b-d96a-bec7a6fc5033"
             class="big-button"
             >Download Now</a
           >
-          <link rel="prerender" href="/download.html" />
+          <link rel="prerender" href="/download" />
           <div class="div-block-3">
             <div
               langfield="or"
@@ -363,13 +363,13 @@
         </div>
       </div>
       <a
-        href="about.html"
+        href="about"
         langfield="about"
         data-w-id="8f4c0691-e692-c061-7fbc-f7242a5caacb"
         class="hollow-button"
         >Learn More</a
       >
-      <link rel="prefetch" href="/about.html" />
+      <link rel="prefetch" href="/about" />
     </div>
     <div class="section">
       <div class="w-container fadein">
@@ -478,18 +478,18 @@
       <a
         langfield="download"
         data-w-id="51fa3c6f-33b6-143c-bfdc-b80a72851377"
-        href="download.html"
+        href="download"
         class="big-button w-button"
         >Download Now</a
       >
-      <link rel="prerender" href="/download.html" />
+      <link rel="prerender" href="/download" />
       <div
         langfield="stillcurious"
         data-w-id="53538a8e-e85e-5660-91a1-27f2591b1aee"
         class="text-block"
       >
-        Still curious? <a href="about.html">Learn More</a>
-        <link rel="prefetch" href="/about.html" />.
+        Still curious? <a href="about">Learn More</a>
+        <link rel="prefetch" href="/about" />.
       </div>
     </div>
     <div class="footer">
@@ -508,10 +508,10 @@
           </div>
           <div class="spc w-col w-col-4">
             <h5 langfield="footer2" class="heading-9">useful links</h5>
-            <a href="about.html" langfield="about" class="footer-link"
+            <a href="about" langfield="about" class="footer-link"
               >Learn More</a
             >
-            <a href="download.html" langfield="download" class="footer-link"
+            <a href="download" langfield="download" class="footer-link"
               >Download Now</a
             >
             <a

--- a/js/lang.js
+++ b/js/lang.js
@@ -1,4 +1,4 @@
-let fileindex = ["index.html", "about.html", "download.html"];
+let fileindex = ["index.html", "about", "download"];
 let traductions = [
   "en",
   "en_US",


### PR DESCRIPTION
This PR removes the `.html` suffix from every page by using a feature in github pages where browsing to a page without extension will default to the file with that name and the `.html` extension, while keeping the extension invisible to the user.

Tested and it works (preview at https://altrisi.github.io/irisshaders.github.io, some links don't work properly there because it's not a root page, specifically links to home, but you can notice they would take you to the root of the domain, that in irisshaders.net is home).

I also fixed the 404 page not working at all when the not found page was being displayed outside of the root directory, since it was useless in those situations before (it used relative references, therefore couldn't find anything in the same directory).

Replaces #13.