### PR TITLE
Fix #63

### DIFF
--- a/about.html
+++ b/about.html
@@ -125,7 +125,7 @@
           <div class="w-icon-nav-menu"></div>
         </div>
       </div>
-      <div class="w-nav-overlay" style="display: inline-block; height: initial">
+      <div class="w-nav-overlay" style="display: inline-block; height: 0px">
         <nav
           role="navigation"
           class="navigation-menu"

--- a/download.html
+++ b/download.html
@@ -124,7 +124,7 @@
           <div class="w-icon-nav-menu"></div>
         </div>
       </div>
-      <div class="w-nav-overlay" style="display: inline-block; height: initial">
+      <div class="w-nav-overlay" style="display: inline-block; height: 0px">
         <nav
           role="navigation"
           class="navigation-menu"

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
           <div class="w-icon-nav-menu"></div>
         </div>
       </div>
-      <div class="w-nav-overlay" style="display: inline-block; height: initial">
+      <div class="w-nav-overlay" style="display: inline-block; height: 0px">
         <nav
           role="navigation"
           class="navigation-menu"


### PR DESCRIPTION
The navigation buttons dropdown menu was invisible but still there, so I set its height to 0px so it wouldn't block everything behind it. 

The height was actually set to 0px if you opened and closed it, but this change means that it also starts with a height of 0px. 

Closes #63